### PR TITLE
chore: add repository URLs in package.json

### DIFF
--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "@rss3/api-core",
 	"version": "0.0.23",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/RSS3-Network/DSL-js-sdk/tree/main/packages/api-core"
+	},
 	"type": "module",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",

--- a/packages/api-react-query/package.json
+++ b/packages/api-react-query/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "@rss3/api-react-query",
 	"version": "0.0.23",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/RSS3-Network/DSL-js-sdk/tree/main/packages/api-react-query"
+	},
 	"type": "module",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",

--- a/packages/api-utils/package.json
+++ b/packages/api-utils/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "@rss3/api-utils",
 	"version": "0.0.23",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/RSS3-Network/DSL-js-sdk/tree/main/packages/api-utils"
+	},
 	"type": "module",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "@rss3/sdk",
 	"version": "0.0.23",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/RSS3-Network/DSL-js-sdk/tree/main/packages/sdk"
+	},
 	"type": "module",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",


### PR DESCRIPTION
So that 
- people can visit the right repo from https://www.npmjs.com/package/@rss3/sdk
- dependabot can parse the changelog like https://github.com/DIYgod/RSSHub/pull/17243 instead of [nothing](https://github.com/DIYgod/RSSHub/pull/17241)

`repository` is inserted in between `version` and `type` because I followed the order [here](https://github.com/keithamus/sort-package-json/blob/99a976083da59a1c1e8237b8a00794ecaaace49f/index.js#L278).